### PR TITLE
Return 400 on webhook handler error

### DIFF
--- a/pages/api/webhooks.js
+++ b/pages/api/webhooks.js
@@ -85,7 +85,7 @@ const webhookHandler = async (req, res) => {
         }
       } catch (error) {
         console.log(error);
-        return res.json({ error: 'Webhook handler failed. View logs.' });
+        return res.status(400).send('Webhook error: "Webhook handler failed. View logs."');
       }
     }
 


### PR DESCRIPTION
Currently returning 200, when there is a webhook handler error. This causes problems when price and product webhooks are fired out of order.
This should fix that.